### PR TITLE
fix double dqn error

### DIFF
--- a/lib/double_dqn_loss.py
+++ b/lib/double_dqn_loss.py
@@ -8,9 +8,9 @@ def calc_loss(batch, net, tgt_net, GAMMA, device="cpu"):
     next_states_v = torch.tensor(next_states).to(device)
     actions_v = torch.tensor(actions).to(device)
     rewards_v = torch.tensor(rewards).to(device)
-    done_mask = torch.ByteTensor(dones).to(device)
+    done_mask = torch.BoolTensor(dones).to(device)
 
-    state_action_values = net(states_v).gather(1, actions_v.unsqueeze(-1)).squeeze(-1)
+    state_action_values = net(states_v).gather(1, actions_v.unsqueeze(-1).type(torch.int64)).squeeze(-1)
     next_state_actions = net(next_states_v).max(1)[1]
     next_state_values = tgt_net(next_states_v).gather(1, next_state_actions.unsqueeze(-1)).unsqueeze(-1)
     next_state_values[done_mask] = 0.0

--- a/lib/double_dqn_loss.py
+++ b/lib/double_dqn_loss.py
@@ -12,7 +12,7 @@ def calc_loss(batch, net, tgt_net, GAMMA, device="cpu"):
 
     state_action_values = net(states_v).gather(1, actions_v.unsqueeze(-1).type(torch.int64)).squeeze(-1)
     next_state_actions = net(next_states_v).max(1)[1]
-    next_state_values = tgt_net(next_states_v).gather(1, next_state_actions.unsqueeze(-1)).unsqueeze(-1)
+    next_state_values = tgt_net(next_states_v).gather(1, next_state_actions.unsqueeze(-1)).squeeze(-1)
     next_state_values[done_mask] = 0.0
     next_state_values = next_state_values.detach()
 


### PR DESCRIPTION
made two small modification to make double dqn work without two errors below

```
Traceback (most recent call last):
  File "dqn_pong.py", line 160, in <module>
    loss_t = loss_calc.calc_loss(batch, net, tgt_net, params["gamma"], device=device)
  File "C:\DevEnv\dqn-pong\lib\double_dqn_loss.py", line 13, in calc_loss
    state_action_values = net(states_v).gather(1, actions_v.unsqueeze(-1)).squeeze(-1)
RuntimeError: gather(): Expected dtype int64 for index
```

```
Traceback (most recent call last):
  File "dqn_pong.py", line 160, in <module>
    loss_t = loss_calc.calc_loss(batch, net, tgt_net, params["gamma"], device=device)
  File "C:\DevEnv\dqn-pong\lib\double_dqn_loss.py", line 16, in calc_loss
    next_state_values[done_mask] = 0.0
RuntimeError: masked_fill only supports boolean masks, but got dtype Byte
```
